### PR TITLE
execute rake commands under bundler context[1]

### DIFF
--- a/wait_for_miq.sh
+++ b/wait_for_miq.sh
@@ -24,12 +24,12 @@ echo "Restarting evm..."
 if [ "$1" == "db" ]; then
 	printRed "RESETTING DB!!"
 	sudo killall ruby &> /dev/null || true
-	rake evm:kill || die_error 'rake evm:kill failed'
+	bundle exec bin/rake evm:kill || die_error 'bundle exec bin/rake evm:kill failed'
 	sleep 3
-	rake evm:db:reset || die_error 'rake evm:db:reset failed'
-	rake evm:start 
+	bundle exec bin/ake evm:db:reset || die_error 'bundle exec bin/rake evm:db:reset failed'
+	bundle exec bin/rake evm:start
 else
-	rake evm:kill evm:start 
+	bundle exec bin/rake evm:kill evm:start
 fi
 
 


### PR DESCRIPTION
also use manageiq rake binary

[1]
"In some cases, running executables without bundle exec may work, if the executable happens to be installed in your system and does not pull in any gems that conflict with your bundle.

However, this is unreliable and is the source of considerable pain. Even if it looks like it works, it may not work in the future or on another machine."

from http://bundler.io/
