### PR TITLE
translate fill_er_up to ruby

### DIFF
--- a/fill_er_up.rb
+++ b/fill_er_up.rb
@@ -1,0 +1,69 @@
+#!/usr/bin/env ruby
+
+# Load Rails
+ENV['RAILS_ENV'] = ARGV[0] || 'development'
+DIR = File.dirname(__FILE__)
+require DIR + '/../manageiq/config/environment'
+
+# --------------------
+# functions and consts
+# --------------------
+
+# delete all providers from database
+def delete_providers
+  ManageIQ::Providers::Kubernetes::ContainerManager.destroy_all
+  ManageIQ::Providers::Openshift::ContainerManager.destroy_all
+end
+
+# insert a new openshift provider to the database
+# hostname  new providers hostname
+def create_prov(hostname)
+  ManageIQ::Providers::Openshift::ContainerManager.new(
+    :hostname => hostname,
+    :name => hostname,
+    :port => 8443,
+    :zone => Zone.first).save
+end
+
+# insert a new openshift provider to the database
+# with authentication
+# name      new providers name
+# hostname  new providers hostname
+# token     new providers token
+def create_prov_with_auth(name, hostname, token)
+  prov = ManageIQ::Providers::Openshift::ContainerManager.new(
+    :hostname => hostname,
+    :name => name,
+    :port => 8443,
+    :zone => Zone.first)
+  prov.save
+
+  AuthToken.create(
+    :name => 'ManageIQ::Providers::Openshift::ContainerManager ' + name,
+    :authtype => 'bearer',
+    :userid => '_',
+    :resource_id => prov.id,
+    :resource_type => 'ExtManagementSystem',
+    :type => 'AuthToken',
+    :auth_key => token).save
+
+  EmsRefresh.refresh(prov)
+end
+
+# ------------------------------------
+# delete the providers in the database
+# and add some new ones
+# ------------------------------------
+
+token1 = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJtYW5hZ2VtZW50LWluZnJhIiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6Im1hbmFnZW1lbnQtYWRtaW4tdG9rZW4tMThmaTAiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC5uYW1lIjoibWFuYWdlbWVudC1hZG1pbiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6ImQ5MjYyYjVjLThmN2ItMTFlNS1hODA2LTAwMWE0YTIzMTI5MCIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDptYW5hZ2VtZW50LWluZnJhOm1hbmFnZW1lbnQtYWRtaW4ifQ.mWvcSwE6_WR8mHm_QBrXM_IHF9I9qOvfB-9Le-g7_DTrzEcM6Jy5smR6v7XmwRizjCheQJxbLjHmATxOXZGxyiG9ZXQGht1TcenCsLKJzxeVp5Lt3K9hdnFdXS9bXNHRav8VNpTwnjS2mRnzGQNxop2BJ1nGWU1mzMSyK5hWKoaUSVKsKwT1UyPfPC6_we-ygjhZpIbSxPEalzm_tjTUFSdWvUFlNBzUQrHvE0zoPxJ4sbbC5uNcaWo7aTey4eIcAn9vnPvNzHTJTIzbVyYIp65jehUr2QKD0CvGAjLWS_Pp-EeINOWaEQe_xNxK0IAl8b4uwhPVc-rRjFb4GkqVoQ'
+
+delete_providers
+create_prov('localhost')
+create_prov_with_auth('Molecule', 'oshift01.eng.lab.tlv.redhat.com', token1)
+
+# ------------------------------
+# do extra stuff on the database
+# ------------------------------
+
+ContainerImageRegistry.create(:host => "exampleHost", :name => "exampleHost", :port=>"1234").save
+


### PR DESCRIPTION
translate fill_er_up to ruby
- users could easily chose to delete / not-delete the current providers.
- chose other providers to pre populate their db with.
- and change tokens.
