### PR TITLE
A script to enable role(s) we need.

### DIFF
--- a/config_roles
+++ b/config_roles
@@ -1,0 +1,2 @@
+#!/bin/sh
+bundle exec rails runner "$0".rb "$@"

--- a/config_roles.rb
+++ b/config_roles.rb
@@ -1,0 +1,17 @@
+# add_roles runs this under rails runner
+
+TO_ADD = ['smartproxy']
+TO_REMOVE = []
+
+def sort_roles(str)
+  str.split(',').sort.join(',')
+end
+
+puts "default: #{sort_roles(Vmdb::Settings.template_settings.server.role)}"
+puts "current: #{sort_roles(Settings.server.role)}"
+
+new_role = ((Settings.server.role.split(',') | TO_ADD) - TO_REMOVE).sort.join(',')
+Vmdb::Settings.save!(MiqServer.my_server(true), {server: {role: new_role}})
+Vmdb::Settings.reload!
+
+puts "    now: #{sort_roles(Settings.server.role)}"


### PR DESCRIPTION
A script to enable smartproxy role.
@moolitayer do we need on any other roles?

Idempotent:

```
bpaskinc@reserved-2-248 ~/m/events (events)> ~/miq-helpers/config_roles
** Using session_store: ActionDispatch::Session::MemCacheStore
default: automate,database_operations,ems_inventory,ems_operations,event,reporting,scheduler,smartstate,user_interface,web_services,websocket
current: automate,database_operations,ems_inventory,ems_operations,event,reporting,scheduler,smartstate,user_interface,web_services,websocket
    now: automate,database_operations,ems_inventory,ems_operations,event,reporting,scheduler,smartproxy,smartstate,user_interface,web_services,websocket
bpaskinc@reserved-2-248 ~/m/events (events)> ~/miq-helpers/config_roles
** Using session_store: ActionDispatch::Session::MemCacheStore
default: automate,database_operations,ems_inventory,ems_operations,event,reporting,scheduler,smartstate,user_interface,web_services,websocket
current: automate,database_operations,ems_inventory,ems_operations,event,reporting,scheduler,smartproxy,smartstate,user_interface,web_services,websocket
    now: automate,database_operations,ems_inventory,ems_operations,event,reporting,scheduler,smartproxy,smartstate,user_interface,web_services,websocket
```

If you have a running evm, probably need to restart to take effect.
