### PR TITLE
Make the load rails more rubust

### DIFF
--- a/fill_er_up.rb
+++ b/fill_er_up.rb
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
 
 # Load Rails
-ENV['RAILS_ENV'] = ARGV[0] || 'development'
 DIR = File.dirname(__FILE__)
-require DIR + '/../manageiq/config/environment'
+require DIR + "/load_rails.rb"
+LoadRails.load_rails
 
 # --------------------
 # functions and consts
@@ -66,4 +66,3 @@ create_prov_with_auth('Molecule', 'oshift01.eng.lab.tlv.redhat.com', token1)
 # ------------------------------
 
 ContainerImageRegistry.create(:host => "exampleHost", :name => "exampleHost", :port=>"1234").save
-

--- a/load_rails.rb
+++ b/load_rails.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+module LoadRails
+  def self.load_rails(db = nil)
+    # For DB use the method variable or environment variable or 'development'
+    ENV['RAILS_ENV'] = db || ENV['RAILS_ENV'] || 'development'
+
+    # If not in development environment, try the production directory
+    begin
+      require './config/environment'
+    rescue LoadError
+      require '/var/www/miq/vmdb/config/environment'
+    end
+  end
+end


### PR DESCRIPTION
When using the load_rails method on systems that are not development it will fail :-( this script will work using the RAILS_ENV env var and the production directory tree.